### PR TITLE
Better exit mechanism for settings

### DIFF
--- a/base.css
+++ b/base.css
@@ -1995,6 +1995,40 @@ div[style*="52.08"] {
     display: none;
 }
 
+/* Added code from Zseni */
+#app-mount .layer-86YKbF ~ .layer-86YKbF .toolsContainer-25FL6V,
+#app-mount .layer-86YKbF ~ .layer-86YKbF .toolsContainer-25FL6V .tools-kIrEGr,
+#app-mount .layer-86YKbF ~ .layer-86YKbF .toolsContainer-25FL6V .container-O54IuJ,
+#app-mount .layer-86YKbF ~ .layer-86YKbF .toolsContainer-25FL6V .closeButton-PCZcma {
+	position: absolute !important;
+	top: 0 !important;
+	right: 0 !important;
+	bottom: 0 !important;
+	left: 0 !important;
+	background: transparent !important;
+	border: none !important;
+	border-radius: 0 !important;
+	width: 100% !important;
+	max-width: unset !important;
+	height: 100% !important;
+	max-height: unset !important;
+	margin: 0 !important;
+	padding: 0 !important;
+}
+#app-mount .layer-86YKbF ~ .layer-86YKbF .toolsContainer-25FL6V,
+#app-mount .layer-86YKbF ~ .layer-86YKbF .toolsContainer-25FL6V .tools-kIrEGr,
+#app-mount .layer-86YKbF ~ .layer-86YKbF .toolsContainer-25FL6V .container-O54IuJ,
+#app-mount .layer-86YKbF ~ .layer-86YKbF .toolsContainer-25FL6V .closeButton-PCZcma svg{
+	position: absolute !important;
+	top: -3px !important;
+	left: 2.5px !important;
+}
+#app-mount .layer-86YKbF ~ .layer-86YKbF .toolsContainer-25FL6V {
+	position: fixed !important;
+	top: 22px !important;
+	z-index: -1 !important;
+}
+
 /* Make PermissionViewers text more consistent with Discords [by christian] */
 .member-perms-title {
     text-transform: uppercase;


### PR DESCRIPTION
#### Reason:
In your theme when you go to settings you have left the server tab to still be visible however when you click on the servers it doesn't do anything, so to me, it seemed sort of pointless. 
#### What it does:
This pull request makes it so when you do click on the servers, acts as an exit button. The original exit button is still there as well.
#### Here is a video showing the difference:
[video](https://user-images.githubusercontent.com/83803826/157420765-c83e0379-74ff-44a6-befb-6b2f6e71ba36.mp4)

