### PR TITLE
Add UserStyle File for Browser Extensions and Brand New README

### DIFF
--- a/Discord11.theme.css
+++ b/Discord11.theme.css
@@ -1,12 +1,12 @@
 /**
  * @name Discord 11
- * @description Based in Windows 11 UI
+ * @description Based on Windows 11's UI
  * @author zuzumi#8097
  * @authorId 403725623161257984
  * @version 2.3.0
  * @invite PsNtzGeHuW
  * @donate https://www.paypal.me/hurtyoutube
- * @website https:github.com/zuzumi-f
+ * @website https://github.com/zuzumi-f
  * @source https://github.com/zuzumi-f/Discord-11/blob/main/base.css
 */
 

--- a/Discord11.user.css
+++ b/Discord11.user.css
@@ -8,7 +8,7 @@
 @preprocessor   stylus
 
 @var select   messageBuble    "Message Buble Style" ["left:Message bubbles in left side*", "default:Default message bubbles", "new:New message bubbles"]
-@var checkbox win11Emojis     "Enable Windows 11 emojis" 0
+@var checkbox win11Emojis     "Enable Windows 11 emojis" 1
 @var checkbox glassEffect     "Enable glass effect (for desktop transparency, the option below must be set to none)" 0
 @var text     wallpaperImage  "Custom wallpaper link (put link inside single quotes)" "'https://wallpapercave.com/wp/wp6051467.jpg'"
 @var text     blurAmount      "Blur amount" 24px

--- a/Discord11.user.css
+++ b/Discord11.user.css
@@ -1,0 +1,53 @@
+/* ==UserStyle==
+@name           Discord 11
+@namespace      github.com/zuzumi-f/Discord-11
+@version        2.3.0
+@description    Based on Windows 11's UI
+@author         Zuzumi
+@updateURL      https://github.com/zuzumi-f/Discord-11/raw/main/Discord11.user.css
+@preprocessor   stylus
+
+@var select   messageBuble    "Message Buble Style" ["left:Message bubbles in left side*", "default:Default message bubbles", "new:New message bubbles"]
+@var checkbox win11Emojis     "Enable Windows 11 emojis" 0
+@var checkbox glassEffect     "Enable glass effect (the option below must be set to none)" 0
+@var text     wallpaperImage  "Custom wallpaper link (put link inside single quotes)" "'https://wallpapercave.com/wp/wp6051467.jpg'"
+@var text     blurAmount      "Blur amount" 24px
+@var number   opacityAmount   "Opacity" [0.6, 0.0, 1.0, 0.1]
+@var text     serverIconsSize "Server icons size" 48px
+@var number   hueAmount       "Hue amount" [206, 0, 239, 1]
+==/UserStyle== */
+
+@-moz-document regexp("https?:\\/\\/(canary\\.)?discord.com/.*") {
+    /* Theme base */
+    @import url(https://zuzumi-f.github.io/Discord-11/base.css);
+
+    /* Message bubles */
+    if messageBuble==left {
+        @import url(https://zuzumi-f.github.io/Discord-11/messagebubbleleft.css);
+    }
+    else if messageBuble==default {
+        @import url(https://zuzumi-f.github.io/Discord-11/messagebubble11.css);
+    }
+    else if messageBuble==new {
+        @import url(https://zuzumi-f.github.io/Discord-11/messagebubblenew.css);
+    }
+
+    /* Windows 11 emojis */
+    if win11Emojis {
+        @import url(https://mwittrien.github.io/BetterDiscordAddons/Themes/EmojiReplace/base/Microsoft.css);
+    }
+
+    /* Glass effect () */
+    if glassEffect {
+        @import url(https://zuzumi-f.github.io/Discord-11/glass-effect.css);
+    }
+
+    /* Settings */
+    :root {
+        --wallpaper-is: url(wallpaperImage) !important;
+        --blur-size: blurAmount !important;
+        --opacity-thing: opacityAmount !important;
+        --server-size: serverIconsSize !important;
+        --hue-color: hueAmount !important;
+    }
+}

--- a/Discord11.user.css
+++ b/Discord11.user.css
@@ -9,7 +9,7 @@
 
 @var select   messageBuble    "Message Buble Style" ["left:Message bubbles in left side*", "default:Default message bubbles", "new:New message bubbles"]
 @var checkbox win11Emojis     "Enable Windows 11 emojis" 0
-@var checkbox glassEffect     "Enable glass effect (the option below must be set to none)" 0
+@var checkbox glassEffect     "Enable glass effect (for desktop transparency, the option below must be set to none)" 0
 @var text     wallpaperImage  "Custom wallpaper link (put link inside single quotes)" "'https://wallpapercave.com/wp/wp6051467.jpg'"
 @var text     blurAmount      "Blur amount" 24px
 @var number   opacityAmount   "Opacity" [0.6, 0.0, 1.0, 0.1]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### [Version 2.3.0!!!](https://github.com/zuzumi-f/Discord-11/releases)
 
-A theme based in windows 11 new UI
+A theme based on Windows 11's UI
 
 Theme by [zuzumi](https://github.com/zuzumi-f)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A theme based on Windows 11's UI - by [zuzumi](https://github.com/zuzumi-f)
 
 - Open https://github.com/zuzumi-f/Discord-11/raw/main/Discord11.user.css
 - Customize for your needs and click install
-> Note: You need to enable CSP patching from your extension's settings, and ake sure you don't have anohter extension that patches CSP. Otherwise theme won't work.
+> Note: You need to enable CSP patching from your extension's settings, and make sure you don't have anohter extension that patches CSP. Otherwise theme won't work.
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -1,65 +1,107 @@
-## Discord 11
+# Discord 11
 
-### [Version 2.3.0!!!](https://github.com/zuzumi-f/Discord-11/releases)
+### [Version 2.3.0 is out!](https://github.com/zuzumi-f/Discord-11/releases)
 
-A theme based on Windows 11's UI
+A theme based on Windows 11's UI - by [zuzumi](https://github.com/zuzumi-f)
 
-Theme by [zuzumi](https://github.com/zuzumi-f)
+- [Discord 11](#discord-11)
+    - [Install](#install)
+        - Third party Discord clients
+        - UserStyle (Stylus, Stylish etc.)
+    - [Screenshots](#screenshots)
+        - [Dark mode](#dark-mode-details)
+        - [Light mode + glass effect](#light-mode-glass-details)
+        - [Message styles](#message-styles)
+            - [Left message bubble](#left-message-bubble)
+            - [Default message bubble](#default-message-bubble)
+            - [New message bubble](#new-message-bubble)
+    - [Customization](#customization)
+        - [Third party Discord clients](#customization-third-party)
+        - [UserStyle (Stylus)](#customization-userstyle-stylus)
+    - [Used Addons](#used-addons)
 
-* [Preview](#preview)
-* [Message Style (Not working)](#message-style)
-    * [Default Style](#left-message-bubble)
-    * [Right (No Autor)](#default-message-bubble)
-    * [Right (Autor)](#new-message-bubble)
-* [Customization](#customization)
-* [Compatibility](#compatibility)
-    * [Horizontal Server List](#hsl)
-* [Addons](#addons)
+## Install
 
-## Preview
+### Third party Discord clients
 
-### Dark Mode
-![Discord_nv3jrt8L82](https://user-images.githubusercontent.com/79029257/197858304-c3c77148-603b-4ed2-88b3-7821efcc1e3f.png)
-![Discord_P0hhYwfz8r](https://user-images.githubusercontent.com/79029257/197858332-522f1da4-6349-4081-a471-635910cdc6c3.png)
+- BandagedDB
+    - Install from https://betterdiscord.app/theme/Discord%2011
+- Goosemod, Powercord, Replugged
+    - Go to Settings > Plugins > Custom CSS
+    - Copy [Discord11.theme.css](Discord11.theme.css) contents and paste into the input box
 
-### Light Mode + Glass Effect
-![Discord_1KWD7oM0T0](https://user-images.githubusercontent.com/79029257/197858375-bf1e7ff4-f586-43ca-8c96-187660c4c7af.png)
-![Discord_u7DFNFaSOp](https://user-images.githubusercontent.com/79029257/197858393-2fe8acfb-86ca-456d-a53e-5af5a80de481.png)
+### UserStyle (Stylus, Stylish etc.)
 
-## Message Style
+- Open https://github.com/zuzumi-f/Discord-11/raw/main/Discord11.user.css
+- Customize for your needs and click install
+> Note: You need to enable CSP patching from your extension's settings, and ake sure you don't have anohter extension that patches CSP. Otherwise theme won't work.
 
-(Messages in RightSide are not working at the moment sorry)
+## Screenshots
 
-### Left Message bubble
-![image](https://user-images.githubusercontent.com/79029257/183246736-7c229bb6-c064-4870-a6eb-744d4bd8d951.png)
+<details id="dark-mode-details">
+    <summary>Dark mode</summary>
 
-### Default Message bubble
-![image](https://user-images.githubusercontent.com/79029257/183246763-c3824133-3e38-4ec1-a7a2-ae415670eff7.png)
+![Dark mode screenshot](https://user-images.githubusercontent.com/79029257/197858304-c3c77148-603b-4ed2-88b3-7821efcc1e3f.png)
+![Dark mode screenshot 2](https://user-images.githubusercontent.com/79029257/197858332-522f1da4-6349-4081-a471-635910cdc6c3.png)
+</details>
 
-### New Message bubble
+<details id="light-mode-glass-details">
+    <summary>Light mode + glass effect</summary>
 
-(Not work with Compact Mode)
+[Light mode + glass effect screenshot](https://user-images.githubusercontent.com/79029257/197858375-bf1e7ff4-f586-43ca-8c96-187660c4c7af.png)
+![Light mode + glass effect screenshot 2](https://user-images.githubusercontent.com/79029257/197858393-2fe8acfb-86ca-456d-a53e-5af5a80de481.png)
+</details>
 
-![image](https://user-images.githubusercontent.com/79029257/183246798-c534587b-37f6-403e-9547-fb46dced9f25.png)
+### Message styles
+
+<details id="left-message-bubble">
+    <summary>Left message buble</summary>
+
+![Left message bubble style](https://user-images.githubusercontent.com/79029257/183246736-7c229bb6-c064-4870-a6eb-744d4bd8d951.png)
+
+</details>
+
+<details id="default-message-bubble">
+    <summary>Default message bubble</summary>
+
+![Default message buble style](https://user-images.githubusercontent.com/79029257/183246763-c3824133-3e38-4ec1-a7a2-ae415670eff7.png)
+</details>
+
+<details id="new-message-bubble">
+    <summary>New message bubble</summary>
+
+> Note: Doesn't work with compact mode
+
+![New message bubble style](https://user-images.githubusercontent.com/79029257/183246798-c534587b-37f6-403e-9547-fb46dced9f25.png)
+</details>
 
 ## Customization
 
-For customization follow the next steps
+<details id="customization-third-party">
+    <summary>Third party Discord clients</summary>
 
-![image](https://user-images.githubusercontent.com/79029257/196771736-bf0421c8-1d16-490e-8003-6c04086224e9.png)
-
-![image](https://user-images.githubusercontent.com/79029257/196772831-6f14281e-2731-47ee-b02e-90eef7e656e1.png)
+![Customize theme step 1](https://user-images.githubusercontent.com/79029257/196771736-bf0421c8-1d16-490e-8003-6c04086224e9.png)
+![Customize theme step 2](https://user-images.githubusercontent.com/79029257/196772831-6f14281e-2731-47ee-b02e-90eef7e656e1.png)
 
 You can write any other code at the bottom of the file
 
-![image](https://user-images.githubusercontent.com/79029257/185492619-98009f68-31c4-4a59-a8dc-e515d22b4363.png)
+![Customize theme step 3](https://user-images.githubusercontent.com/79029257/185492619-98009f68-31c4-4a59-a8dc-e515d22b4363.png)
+</details>
+
+<details id="customization-userstyle-stylus">
+    <summary>UserStyle (Stylus)</summary>
+
+![Customize theme step 1](https://i.imgur.com/KQ9bEnh.png)
+![Customize theme step 2](https://i.imgur.com/G88mLLd.png)
+</details>
 
 ## Compatibility
 
-### HSL
+### Horizontial Server List plugin
+
+You need to add the following CSS to the theme's CSS for it to work. [Check here for how customize the CSS](#customization).
 
 ```css
-
 #app-mount .guilds-2JjMmN [class*=expandedFolderBackground] {
     border-radius: var(--winrad2) !important;
     left: calc(var(--server-size)/2) !important;
@@ -86,13 +128,15 @@ You can write any other code at the bottom of the file
 }
 ```
 
-## Addons
-* Discolored by **[Nyri4](https://github.com/NYRI4/Discolored)**
 
-* Fluent Icons by **[Stickfab](https://github.com/stickfab/pc-fluenticons)**
+## Used Addons
 
-* Emoji Replace by **[DevilBro](https://github.com/mwittrien/BetterDiscordAddons/blob/master/Themes/EmojiReplace/EmojiReplace.theme.css)**
+- Discolored by **[Nyri4](https://github.com/NYRI4/Discolored)**
 
-* FriendGrid by **[CorellanStoma](https://github.com/CreArts-Community/Friends-Grid)**
+- Fluent Icons by **[Stickfab](https://github.com/stickfab/pc-fluenticons)**
 
-* BearableInbox by **[Disease](https://github.com/maenDisease/BetterDiscordStuff/blob/main/css/bearableInbox.css)**
+- Emoji Replace by **[DevilBro](https://github.com/mwittrien/BetterDiscordAddons/blob/master/Themes/EmojiReplace/EmojiReplace.theme.css)**
+
+- FriendsGrid by **[CorellanStoma](https://github.com/CreArts-Community/Friends-Grid)**
+
+- BearableInbox by **[Disease](https://github.com/maenDisease/BetterDiscordStuff/blob/main/css/bearableInbox.css)**

--- a/README.md
+++ b/README.md
@@ -91,8 +91,7 @@ You can write any other code at the bottom of the file
 <details id="customization-userstyle-stylus">
     <summary>UserStyle (Stylus)</summary>
 
-![Customize theme step 1](https://i.imgur.com/KQ9bEnh.png)
-![Customize theme step 2](https://i.imgur.com/G88mLLd.png)
+![Customize theme step 1](https://i.imgur.com/G88mLLd.png)
 </details>
 
 ## Compatibility

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A theme based on Windows 11's UI - by [zuzumi](https://github.com/zuzumi-f)
 
 ### Third party Discord clients
 
-- BandagedDB
+- BandagedBD
     - Install from https://betterdiscord.app/theme/Discord%2011
 - Goosemod, Powercord, Replugged
     - Go to Settings > Plugins > Custom CSS


### PR DESCRIPTION
## Things to note
- It's not required to bump version on [Discord11.user.css](Discord11.user.css) file, but bumping will be better.
- Glass mode for desktop might not work since browsers doesn't support transparency. There are third party applications that make every window transparent, but I'm not sure if they will work.