### PR TITLE
fix settings page gap not shrinking when resizing

### DIFF
--- a/base.css
+++ b/base.css
@@ -4842,7 +4842,8 @@ html {
     padding: 16px;
 }
 #app-mount .contentColumnDefault-3eyv5o {
-    padding: 16px 30vh 24px;
+    max-width: 50vw;
+    margin: auto;
 }
 
 /* Server Upload Image */


### PR DESCRIPTION
Fixes https://github.com/zuzumi-f/Discord-11/issues/17#issuecomment-1307889097, closes #17

Instead of using padding, I used viewport width to make its size dynamic for different screen sizes. And with auto margin touch, it centers the content. Here's how it looks;

<details>
  <summary>My initial screen size (1366×768)</summary>

![image](https://user-images.githubusercontent.com/108196023/200811722-5c0e4ef0-db89-48a7-b2ac-48d7a0277b65.png)
</details>

<details>
  <summary>1920×1080 <i>(dev tools is because I don't have 1920×1080 monitor)</i></summary>

![image](https://user-images.githubusercontent.com/108196023/200812936-16ae1d14-c35f-49ec-a8b9-be914ec7cce7.png)
</details>
