### PR TITLE
Update base.css

### DIFF
--- a/base.css
+++ b/base.css
@@ -1067,6 +1067,9 @@
 #app-mount .botTag_a02df3 svg path {
     fill: var(--status-warning-text);
 }
+#app-mount .botText_a02df3 {
+    font-size: .6rem !important;
+}
 
 /* Server Banner */
 #app-mount .header_fd6364 {
@@ -1342,12 +1345,12 @@ div[class="container_fd6364 clickable_fd6364 hasBanner_fd6364 bannerVisible_fd63
 
 /* Embeds */
 .theme-dark .embedFull_ad0b71 {
-    border: 2px solid;
+    border-left: 2px solid;
     background: var(--windark-acrylic);
 }
 .theme-light .embedFull_ad0b71 {
     background: var(--winlight-acrylic);
-    border: 2px solid;
+    border-left: 2px solid;
 }
 
 /* Everyone warning */


### PR DESCRIPTION
I changed 2 things, the border on the embeds. I found that 2px all the way around the embeds didn't look nearly as nice or fluid as just off to the left. Though, the 2px is much more subtle then the default 4, i think it looks pretty crisp this way.

I also changed the bot-tag font size, looks too big at .8rem, so i changed .6rem. Here's a photo for reference.

![image](https://github.com/zuzumi-f/Discord-11/assets/43388217/d613d42d-28aa-4b57-89c9-f16d2575917c)
